### PR TITLE
We should be setting the content-length in our error handling so that…

### DIFF
--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -33,7 +33,10 @@ module.exports = function create(fittingDef, bagpipes) {
       Object.defineProperty(err, 'message', { enumerable: true }); // include message property in response
 
       delete(context.error);
-      next(null, JSON.stringify(err));
+
+      var result = JSON.stringify(err)
+      context.response.set('Content-Length', result.length)
+      next(null, result);
     } catch (err2) {
       debug('jsonErrorHandler unable to stringify error: %j', err);
       next();


### PR DESCRIPTION
… incomplete messages aren't returned to the client.
