### PR TITLE
Added callback to controllerFunction catch if it is Promise/async func

### DIFF
--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -99,9 +99,13 @@ module.exports = function create(fittingDef, bagpipes) {
         }
         
         debug('running controller, as %s', operation.controllerInterface);
-        return operation.controllerInterface == 'pipe'
+        var resolvedFunction = operation.controllerInterface == 'pipe'
           ? controllerFunction(context, cb)
           : controllerFunction(context.request, context.response, cb);
+          
+        if (resolvedFunction instanceof Promise) resolvedFunction.catch(cb);
+        
+        return resolvedFunction;
       }
 
       var msg = util.format('Controller %s doesn\'t export handler function %s', controllerName, operationId);


### PR DESCRIPTION
**Tested: node v8.1.2**

Thought it would be appropriate that if the evoked controllerFunction is an async function, have it handle the callback when an error is thrown by having the callback within its catch method instead of giving an unhandled promise rejection error.

Example:
```
async function hello(req, res) {
  throw Error("Hello");
}

// Results in this error, and the request never resolves
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Hello
```

Fixed:
```
async function hello(req, res) {
  throw Error("Hello");
}

// Error stack properly displayed in stderr, request continues on to whatever error handler
```
