### PR TITLE
added the code for the query parameter decoding, passed the custom de…

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,11 +8,24 @@ var qs = require('qs');
 var parseUrl = require('parseurl');
 var debug = require('debug')('swagger');
 
+
+// custom decoder function
+var decode = function (str) {
+    try {
+        return decodeURIComponent(str);
+    } catch (e) {
+        return str;
+    }
+};
+
+//qs module options
+var qsOptions = { decoder : decode};
+
 // side-effect: stores in query property on req
 function queryString(req) {
   if (!req.query) {
     var url = parseUrl(req);
-    req.query = (url.query) ? qs.parse(url.query) : {};
+    req.query = (url.query) ? qs.parse(url.query, qsOptions) : {};
   }
   return req.query;
 }


### PR DESCRIPTION
…coder function to the qs module parse function.

While passing the plus sign in the query parameter it got replaced with Space. In order to avoid that passed a custom decoder to resolve the issue